### PR TITLE
add seq num to version; change header names; multi-param support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,22 +15,31 @@ project(${TARGET_NAME})
 include_directories(src/include ${DuckDB_SOURCE_DIR}/third_party/httplib)
 
 set(EXTENSION_SOURCES
-    src/ui_extension.cpp
     src/event_dispatcher.cpp
     src/http_server.cpp
     src/settings.cpp
     src/state.cpp
-    src/watcher.cpp
+    src/ui_extension.cpp
     src/utils/encoding.cpp
     src/utils/env.cpp
     src/utils/helpers.cpp
     src/utils/md_helpers.cpp
-    src/utils/serialization.cpp)
+    src/utils/serialization.cpp
+    src/watcher.cpp)
 
 find_package(Git)
 if(NOT Git_FOUND)
   message(FATAL_ERROR "Git not found, unable to determine git sha")
 endif()
+
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  OUTPUT_VARIABLE UI_EXTENSION_SEQ_NUM
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+message(STATUS "UI_EXTENSION_SEQ_NUM=${UI_EXTENSION_SEQ_NUM}")
+add_definitions(-DUI_EXTENSION_SEQ_NUM="${UI_EXTENSION_SEQ_NUM}")
 
 execute_process(
   COMMAND ${GIT_EXECUTABLE} rev-parse --short=10 HEAD

--- a/src/include/version.hpp
+++ b/src/include/version.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifndef UI_EXTENSION_SEQ_NUM
+#error "UI_EXTENSION_SEQ_NUM must be defined"
+#endif
+#ifndef UI_EXTENSION_GIT_SHA
+#error "UI_EXTENSION_GIT_SHA must be defined"
+#endif
+#define UI_EXTENSION_VERSION UI_EXTENSION_SEQ_NUM "-" UI_EXTENSION_GIT_SHA

--- a/src/ui_extension.cpp
+++ b/src/ui_extension.cpp
@@ -9,6 +9,7 @@
 #include "ui_extension.hpp"
 #include "utils/env.hpp"
 #include "utils/helpers.hpp"
+#include "version.hpp"
 
 #ifdef _WIN32
 #define OPEN_COMMAND "start"
@@ -108,13 +109,7 @@ static void LoadInternal(DatabaseInstance &instance) {
 void UiExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }
 std::string UiExtension::Name() { return "ui"; }
 
-std::string UiExtension::Version() const {
-#ifdef UI_EXTENSION_GIT_SHA
-  return UI_EXTENSION_GIT_SHA;
-#else
-  return "";
-#endif
-}
+std::string UiExtension::Version() const { return UI_EXTENSION_VERSION; }
 
 } // namespace duckdb
 


### PR DESCRIPTION
- Add a sequence number to the extension version.
- Return the extension version, plus the DuckDB version and platform, in headers in the /config call.
- Accept alternate header names without `MD`. Accept both styles until we change the UI.
- Accept alternate way of supplying multiple parameters.
- Remove obsolete references to MD-internal issues.