### PR TITLE
check for running on machine before starting

### DIFF
--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -55,6 +55,22 @@ void HttpServer::UpdateDatabaseInstance(
   }
 }
 
+bool HttpServer::IsRunningOnMachine(ClientContext &context) {
+  if (Started()) {
+    return true;
+  }
+
+  const auto local_port = GetLocalPort(context);
+  auto local_url = StringUtil::Format("http://localhost:%d", local_port);
+
+  httplib::Client client(local_url);
+  auto result = client.Get("/info");
+  if (result) {
+    return true;
+  }
+  return false;
+}
+
 bool HttpServer::Started() {
   return server_instance && server_instance->main_thread;
 }

--- a/src/include/http_server.hpp
+++ b/src/include/http_server.hpp
@@ -24,13 +24,16 @@ class HttpServer {
 public:
   HttpServer(shared_ptr<DatabaseInstance> _ddb_instance)
       : ddb_instance(_ddb_instance) {}
+
   static HttpServer *GetInstance(ClientContext &);
   static void UpdateDatabaseInstanceIfRunning(shared_ptr<DatabaseInstance>);
+  static bool IsRunningOnMachine(ClientContext &);
   static bool Started();
   static void StopInstance();
 
   static const HttpServer &Start(ClientContext &, bool *was_started = nullptr);
   static bool Stop();
+
   std::string LocalUrl() const;
 
 private:

--- a/src/ui_extension.cpp
+++ b/src/ui_extension.cpp
@@ -22,6 +22,11 @@
 namespace duckdb {
 
 std::string StartUIFunction(ClientContext &context) {
+  if (!ui::HttpServer::Started() &&
+      ui::HttpServer::IsRunningOnMachine(context)) {
+    return "UI already running in a different DuckDB instance";
+  }
+
   const auto &server = ui::HttpServer::Start(context);
   const auto local_url = server.LocalUrl();
 
@@ -33,6 +38,11 @@ std::string StartUIFunction(ClientContext &context) {
 }
 
 std::string StartUIServerFunction(ClientContext &context) {
+  if (!ui::HttpServer::Started() &&
+      ui::HttpServer::IsRunningOnMachine(context)) {
+    return "UI already running in a different DuckDB instance";
+  }
+
   bool was_started = false;
   const auto &server = ui::HttpServer::Start(context, &was_started);
   const char *already = was_started ? "already " : "";


### PR DESCRIPTION
If the DuckDB UI server with the same local port is already running on the machine (e.g. in a different DuckDB instance), then return an error message instead of trying to start it again (which will not work properly).