### PR TITLE
check origin header

### DIFF
--- a/src/include/http_server.hpp
+++ b/src/include/http_server.hpp
@@ -69,6 +69,7 @@ private:
   shared_ptr<DatabaseInstance> LockDatabaseInstance();
 
   uint16_t local_port;
+  std::string local_url;
   std::string remote_url;
   weak_ptr<DatabaseInstance> ddb_instance;
   std::string user_agent;


### PR DESCRIPTION
To prevent requests from browser pages on localhost but on a different port, check the "Origin" header (or "Referer", in the case of GET requests) instead of "Sec-Fetch-Site".