### PR TITLE
ci: Enable windows_amd64_mingw

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       ci_tools_version: main
       duckdb_version: main
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
       extension_name: ui
   
   duckdb-next-patch-build:
@@ -27,7 +27,7 @@ jobs:
     with:
       ci_tools_version: v1.2.1
       duckdb_version: v1.2-histrionicus
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
       extension_name: ui
 
   duckdb-stable-build:
@@ -36,7 +36,7 @@ jobs:
     with:
       ci_tools_version: v1.2.1
       duckdb_version: v1.2.1
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
       extension_name: ui
 
   duckdb-stable-deploy:
@@ -49,5 +49,5 @@ jobs:
       extension_name: ui
       duckdb_version: v1.2.1
       ci_tools_version: v1.2.1
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
cf. https://github.com/duckdb/extension-ci-tools/pull/153

I believe there's no strong reason to exclude `windows_amd64_mingw`. This pull request reflects the change in extension-ci-tools to support `windows_amd64_mingw`.