### PR TITLE
Add `get_ui_url` function

### DIFF
--- a/src/ui_extension.cpp
+++ b/src/ui_extension.cpp
@@ -55,6 +55,15 @@ std::string StopUIServerFunction(ClientContext &context) {
                                 : "UI server already stopped";
 }
 
+std::string GetUIURLFunction(ClientContext &context) {
+  if (!ui::HttpServer::Started()) {
+    throw ExecutorException("UI server not started");
+  }
+
+  auto server = ui::HttpServer::GetInstance(context);
+  return server->LocalUrl();
+}
+
 void IsUIStartedTableFunc(ClientContext &context, TableFunctionInput &input,
                           DataChunk &output) {
   if (!internal::ShouldRun(input)) {
@@ -114,6 +123,7 @@ static void LoadInternal(DatabaseInstance &instance) {
   REGISTER_TF("start_ui", StartUIFunction);
   REGISTER_TF("start_ui_server", StartUIServerFunction);
   REGISTER_TF("stop_ui_server", StopUIServerFunction);
+  REGISTER_TF("get_ui_url", GetUIURLFunction);
   {
     TableFunction tf("ui_is_started", {}, IsUIStartedTableFunc,
                      internal::SingleBoolResultBind,


### PR DESCRIPTION
As reported in https://github.com/duckdb/duckdb-ui/issues/35, users would like to have a way to get the UI url.

This PR adds a simple `get_ui_url` table function such that:
```sql
-- Raise an error when server is not started:
D from get_ui_url();
Executor Error:
UI server not started

-- Returns the URL if it is:
D from get_ui_url();
┌────────────────────────┐
│         result         │
│        varchar         │
├────────────────────────┤
│ http://localhost:4213/ │
└────────────────────────┘
```