### PR TITLE
Don't duplicate Content-Length

### DIFF
--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -269,6 +269,9 @@ void HttpServer::HandleGet(const httplib::Request &req,
     // Wasm).
     res.set_header("X-DuckDB-UI-Extension-Version", UI_EXTENSION_VERSION);
   }
+
+  // httplib will set Content-Length, remove it so it is not duplicated.
+  res.headers.erase("Content-Length");
 }
 
 void HttpServer::HandleInterrupt(const httplib::Request &req,


### PR DESCRIPTION
As reported in https://github.com/duckdb/duckdb-ui/issues/52, forwarded HTTP requests were including a duplicated `Content-Length` header:

```bash
curl -vvv http://localhost:4213/
*   Trying 127.0.0.1:4213...
* connect to 127.0.0.1 port 4213 failed: Connection refused
*   Trying [::1]:4213...
* Connected to localhost (::1) port 4213 (#0)
> GET / HTTP/1.1
> Host: localhost:4213
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Age: 69823
< Cache-Control: max-age=0, s-maxage=3600
< Connection: keep-alive
< Content-Length: 507
< Content-Length: 507
```

With this PR:
```bash
$ curl -vvv http://localhost:4213/          
* Host localhost:4213 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:4213...
* Connected to localhost (::1) port 4213
> GET / HTTP/1.1
> Host: localhost:4213
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Age: 46683
< Cache-Control: max-age=0, s-maxage=3600
< Connection: keep-alive
< Content-Length: 507
< Content-Type: text/html
< Cross-Origin-Embedder-Policy: require-corp
< Cross-Origin-Opener-Policy: same-origin
< Date: Mon, 17 Mar 2025 19:10:41 GMT
< ETag: "78403e379249f9d6f701eb7ed6284fa0"
< Keep-Alive: timeout=5, max=5
< Last-Modified: Thu, 13 Mar 2025 17:20:05 GMT
< Server: AmazonS3
< Via: 1.1 3f1a5dbb6451309426050e13abf469c6.cloudfront.net (CloudFront)
< X-Amz-Cf-Id: kEkD1SncxqJj-CuyAdUECtrjWq0LQ9Mh4Kt37T7SVf0asOHUYWtIEA==
< X-Amz-Cf-Pop: CDG50-P1
< x-amz-id-2: 83B8Vmzwhnp2V4j3OW7Y0hrsijTomqWkQZFWCKKXwz1TVr/3N6dJtZ+1FtiBjp2hH9KUyGROKk8=
< x-amz-request-id: XQR1M45B6TV6FEX9
< x-amz-server-side-encryption: AES256
< X-Cache: Hit from cloudfront
< 
<!doctype html><html lang="en"><head><meta charset="UTF-8"/><meta name=
...
```