### PR TITLE
Send error when fetching remote assets fails

### DIFF
--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -255,6 +255,9 @@ void HttpServer::HandleGet(const httplib::Request &req,
   auto result = client.Get(req.path, req.params, {{"User-Agent", user_agent}});
   if (!result) {
     res.status = 500;
+    res.set_content("Could not fetch: '" + req.path + "' from '" + remote_url +
+                        "': " + to_string(result.error()),
+                    "text/plain");
     return;
   }
 


### PR DESCRIPTION
As reported in https://github.com/duckdb/duckdb-ui/issues/95, some users are facing certificate validation issues.

Unfortunately, in the current code we do not forward the actual error message, making it harder to debug. This PR fixes it.