### PR TITLE
Only build on PR or pushes on main

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -4,6 +4,8 @@
 name: Main Extension Distribution Pipeline
 on:
   push:
+    branches:
+      - "main"
   pull_request:
   workflow_dispatch:
 
@@ -20,7 +22,7 @@ jobs:
       duckdb_version: main
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
       extension_name: ui
-  
+
   duckdb-next-patch-build:
     name: Build next patch extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.2.1


### PR DESCRIPTION
Currently all PRs are built twice: once trough the `pull_request` event and once through the `push` one. This PR only accept `push` events coming from `main` branch