### PR TITLE
add support for pivot

### DIFF
--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -385,8 +385,7 @@ void HttpServer::DoHandleRun(const httplib::Request &req,
   // If there's more than one statement, run all but the last.
   if (statement_count > 1) {
     for (auto i = 0; i < statement_count - 1; ++i) {
-      auto &statement = statements[i];
-      auto pending = connection->PendingQuery(std::move(statement));
+      auto pending = connection->PendingQuery(std::move(statements[i]));
       // Return any error found before execution.
       if (pending->HasError()) {
         SetResponseErrorResult(res, pending->GetError());
@@ -412,7 +411,9 @@ void HttpServer::DoHandleRun(const httplib::Request &req,
         pending->Execute();
         break;
       default:
-        SetResponseErrorResult(res, "Unexpected PendingExecutionResult");
+        SetResponseErrorResult(
+            res, StringUtil::Format("Unexpected PendingExecutionResult: %d",
+                                    exec_result));
         return;
       }
     }
@@ -488,7 +489,9 @@ void HttpServer::DoHandleRun(const httplib::Request &req,
     break;
   }
   default:
-    SetResponseErrorResult(res, "Unexpected PendingExecutionResult");
+    SetResponseErrorResult(
+        res, StringUtil::Format("Unexpected PendingExecutionResult: %d",
+                                exec_result));
     break;
   }
 }

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -412,7 +412,7 @@ void HttpServer::DoHandleRun(const httplib::Request &req,
         break;
       default:
         SetResponseErrorResult(
-            res, StringUtil::Format("Unexpected PendingExecutionResult: %d",
+            res, StringUtil::Format("Unexpected PendingExecutionResult: %s",
                                     exec_result));
         return;
       }
@@ -490,7 +490,7 @@ void HttpServer::DoHandleRun(const httplib::Request &req,
   }
   default:
     SetResponseErrorResult(
-        res, StringUtil::Format("Unexpected PendingExecutionResult: %d",
+        res, StringUtil::Format("Unexpected PendingExecutionResult: %s",
                                 exec_result));
     break;
   }


### PR DESCRIPTION
The PIVOT statement is transformed into multiple statements by the parser, so running it directly in PendingQuery (which only supports a single statement) results in an error. Instead, we can use ExtractStatements to get the actual statements resulting from the transform, and run those separately.