### PR TITLE
Add support for new extension loader

### DIFF
--- a/src/include/ui_extension.hpp
+++ b/src/include/ui_extension.hpp
@@ -6,7 +6,12 @@ namespace duckdb {
 
 class UiExtension : public Extension {
 public:
+#ifdef DUCKDB_CPP_EXTENSION_ENTRY
+  void Load(ExtensionLoader &loader) override;
+#else
   void Load(DuckDB &db) override;
+#endif
+
   std::string Name() override;
   std::string Version() const override;
 };

--- a/src/ui_extension.cpp
+++ b/src/ui_extension.cpp
@@ -13,6 +13,7 @@
 
 #ifdef _WIN32
 #define OPEN_COMMAND "start"
+#undef CreateDirectory // avoid being transformed to `CreateDirectoryA`
 #elif __linux__
 #define OPEN_COMMAND "xdg-open"
 #else


### PR DESCRIPTION
DuckDB extension loader was revamped in https://github.com/duckdb/duckdb/pull/17772.
This PR keeps support for DuckDB <= 1.3.0 and add support for the new loading API.

We rely on the `DUCKDB_CPP_EXTENSION_ENTRY` macro presence since core DuckDB doesn't know about the `ui` extension in its [build system](https://github.com/duckdb/duckdb/blob/main/.github/config/out_of_tree_extensions.cmake), so we can't rely on the `patch` approach.