### PR TITLE
Add ui_local_host setting to configure server bind address

### DIFF
--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -101,25 +101,28 @@ const HttpServer &HttpServer::Start(ClientContext &context, bool *was_started) {
     *was_started = false;
   }
 
+  const auto host = GetLocalHost(context);
   const auto remote_url = GetRemoteUrl(context);
   const auto port = GetLocalPort(context);
   auto &http_util = HTTPUtil::Get(*context.db);
   // FIXME - https://github.com/duckdb/duckdb/pull/17655 will remove `unused`
   auto http_params = http_util.InitializeParameters(context, "unused");
   auto server = GetInstance(context);
-  server->DoStart(port, remote_url, std::move(http_params));
+  server->DoStart(host, port, remote_url, std::move(http_params));
   return *server;
 }
 
-void HttpServer::DoStart(const uint16_t _local_port,
+void HttpServer::DoStart(const std::string &_local_host,
+                         const uint16_t _local_port,
                          const std::string &_remote_url,
                          unique_ptr<HTTPParams> _http_params) {
   if (Started()) {
     throw std::runtime_error("HttpServer already started");
   }
 
+  local_host = _local_host;
   local_port = _local_port;
-  local_url = StringUtil::Format("http://localhost:%d", local_port);
+  local_url = StringUtil::Format("http://%s:%d", local_host, local_port);
   remote_url = _remote_url;
   http_params = std::move(_http_params);
   user_agent =
@@ -163,11 +166,12 @@ void HttpServer::DoStop() {
   http_params = nullptr;
   event_dispatcher = nullptr;
   remote_url = "";
+  local_host = "";
   local_port = 0;
 }
 
 std::string HttpServer::LocalUrl() const {
-  return StringUtil::Format("http://localhost:%d/", local_port);
+  return StringUtil::Format("http://%s:%d/", local_host, local_port);
 }
 
 shared_ptr<DatabaseInstance> HttpServer::LockDatabaseInstance() {
@@ -203,7 +207,7 @@ void HttpServer::Run() {
                   const httplib::ContentReader &content_reader) {
                 HandleTokenize(req, res, content_reader);
               });
-  server.listen("localhost", local_port);
+  server.listen(local_host, local_port);
 }
 
 void HttpServer::HandleGetInfo(const httplib::Request &req,

--- a/src/include/http_server.hpp
+++ b/src/include/http_server.hpp
@@ -42,8 +42,8 @@ private:
   friend class Watcher;
 
   // Lifecycle
-  void DoStart(const uint16_t local_port, const std::string &remote_url,
-               unique_ptr<HTTPParams>);
+  void DoStart(const std::string &local_host, const uint16_t local_port,
+               const std::string &remote_url, unique_ptr<HTTPParams>);
   void DoStop();
   void Run();
   void UpdateDatabaseInstance(shared_ptr<DatabaseInstance> context_db);
@@ -75,6 +75,7 @@ private:
   static void CopyAndSlice(duckdb::DataChunk &source, duckdb::DataChunk &target,
                            idx_t row_count);
 
+  std::string local_host;
   uint16_t local_port;
   std::string local_url;
   std::string remote_url;

--- a/src/include/settings.hpp
+++ b/src/include/settings.hpp
@@ -3,6 +3,8 @@
 #include <duckdb/common/exception.hpp>
 #include <duckdb/main/client_context.hpp>
 
+#define UI_LOCAL_HOST_SETTING_NAME "ui_local_host"
+#define UI_LOCAL_HOST_SETTING_DEFAULT "localhost"
 #define UI_LOCAL_PORT_SETTING_NAME "ui_local_port"
 #define UI_LOCAL_PORT_SETTING_DEFAULT 4213
 #define UI_REMOTE_URL_SETTING_NAME "ui_remote_url"
@@ -25,6 +27,7 @@ T GetSetting(const ClientContext &context, const char *setting_name) {
 }
 } // namespace internal
 
+std::string GetLocalHost(const ClientContext &);
 std::string GetRemoteUrl(const ClientContext &);
 uint16_t GetLocalPort(const ClientContext &);
 uint32_t GetPollingInterval(const ClientContext &);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -20,6 +20,10 @@ std::string GetRemoteUrl(const ClientContext &context) {
   return internal::GetSetting<std::string>(context, UI_REMOTE_URL_SETTING_NAME);
 }
 
+std::string GetLocalHost(const ClientContext &context) {
+  return internal::GetSetting<std::string>(context, UI_LOCAL_HOST_SETTING_NAME);
+}
+
 uint16_t GetLocalPort(const ClientContext &context) {
   return internal::GetSetting<uint16_t>(context, UI_LOCAL_PORT_SETTING_NAME);
 }

--- a/src/ui_extension.cpp
+++ b/src/ui_extension.cpp
@@ -108,6 +108,15 @@ static void LoadInternal(DatabaseInstance &instance) {
 
   auto &config = DBConfig::GetConfig(instance);
   {
+    auto def = GetEnvOrDefault(UI_LOCAL_HOST_SETTING_NAME,
+                               UI_LOCAL_HOST_SETTING_DEFAULT);
+    config.AddExtensionOption(
+        UI_LOCAL_HOST_SETTING_NAME,
+        "Local host on which the UI server listens",
+        LogicalType::VARCHAR, Value(def));
+  }
+
+  {
     auto default_port = GetEnvOrDefaultInt(UI_LOCAL_PORT_SETTING_NAME,
                                            UI_LOCAL_PORT_SETTING_DEFAULT);
     config.AddExtensionOption(

--- a/test/sql/ui.test
+++ b/test/sql/ui.test
@@ -2,3 +2,25 @@
 # description: test ui extension
 # group: [sql]
 
+require ui
+
+# Verify the ui_local_host setting exists with the default value
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_local_host';
+----
+ui_local_host	localhost
+
+# Verify the ui_local_host setting can be changed
+statement ok
+SET ui_local_host = '0.0.0.0';
+
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_local_host';
+----
+ui_local_host	0.0.0.0
+
+# Verify the ui_local_port setting still works
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_local_port';
+----
+ui_local_port	4213


### PR DESCRIPTION
## Summary
- Add a new `ui_local_host` DuckDB extension setting (default: `localhost`) that controls the host/address the UI HTTP server binds to.
- Enables binding to `0.0.0.0` for remote/network access, e.g. `SET ui_local_host = '0.0.0.0';` or `UI_LOCAL_HOST=0.0.0.0 duckdb -ui`.
- Follows the same pattern as the existing `ui_local_port` setting: configurable via SQL, environment variable, or default.

## Changes
- **`src/include/settings.hpp`** — Define `UI_LOCAL_HOST_SETTING_NAME` / `UI_LOCAL_HOST_SETTING_DEFAULT` macros, declare `GetLocalHost()`.
- **`src/settings.cpp`** — Implement `GetLocalHost()`.
- **`src/ui_extension.cpp`** — Register `ui_local_host` as an extension option (`VARCHAR`, env-overridable).
- **`src/include/http_server.hpp`** — Add `local_host` member, update `DoStart` signature.
- **`src/http_server.cpp`** — Thread `local_host` through `Start`→`DoStart`→`Run`, use it in `server.listen()`, `LocalUrl()`, and `local_url` construction. `IsRunningOnMachine()` still probes `localhost` since that works regardless of bind address.
- **`test/sql/ui.test`** — Add SQLLogicTests verifying the setting exists, has the correct default, and can be changed.