### PR TITLE
Add UI setting to bind to 0.0.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ testext
 test/python/__pycache__/
 .Rhistory
 .vscode/
+node_modules/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(EXTENSION_SOURCES
     src/utils/helpers.cpp
     src/utils/md_helpers.cpp
     src/utils/serialization.cpp
+    src/utils/token.cpp
     src/watcher.cpp)
 
 add_definitions(-DDUCKDB_MAJOR_VERSION=${DUCKDB_MAJOR_VERSION})

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -4,6 +4,7 @@
 #include "settings.hpp"
 #include "state.hpp"
 #include "utils/encoding.hpp"
+#include "utils/token.hpp"
 #include "utils/env.hpp"
 #include "utils/helpers.hpp"
 #include "utils/md_helpers.hpp"
@@ -108,14 +109,16 @@ const HttpServer &HttpServer::Start(ClientContext &context, bool *was_started) {
   // FIXME - https://github.com/duckdb/duckdb/pull/17655 will remove `unused`
   auto http_params = http_util.InitializeParameters(context, "unused");
   auto server = GetInstance(context);
-  server->DoStart(host, port, remote_url, std::move(http_params));
+  const auto token_auth = GetEnableTokenAuth(context);
+  server->DoStart(host, port, remote_url, std::move(http_params), token_auth);
   return *server;
 }
 
 void HttpServer::DoStart(const std::string &_local_host,
                          const uint16_t _local_port,
                          const std::string &_remote_url,
-                         unique_ptr<HTTPParams> _http_params) {
+                         unique_ptr<HTTPParams> _http_params,
+                         bool _token_auth_enabled) {
   if (Started()) {
     throw std::runtime_error("HttpServer already started");
   }
@@ -125,6 +128,8 @@ void HttpServer::DoStart(const std::string &_local_host,
   local_url = StringUtil::Format("http://%s:%d", local_host, local_port);
   remote_url = _remote_url;
   http_params = std::move(_http_params);
+  token_auth_enabled = _token_auth_enabled;
+  auth_token = GenerateToken();
   user_agent =
       StringUtil::Format("duckdb-ui/%s-%s(%s)", DuckDB::LibraryVersion(),
                          UI_EXTENSION_VERSION, DuckDB::Platform());
@@ -174,6 +179,66 @@ std::string HttpServer::LocalUrl() const {
   return StringUtil::Format("http://%s:%d/", local_host, local_port);
 }
 
+std::string HttpServer::GetAuthToken() const {
+  return auth_token;
+}
+
+std::string HttpServer::ExtractTokenFromCookie(const std::string &cookie_header) {
+  const std::string prefix = "duckdb_ui_token=";
+  size_t pos = cookie_header.find(prefix);
+  if (pos == std::string::npos) {
+    return "";
+  }
+  pos += prefix.size();
+  size_t end = cookie_header.find(';', pos);
+  if (end == std::string::npos) {
+    return cookie_header.substr(pos);
+  }
+  return cookie_header.substr(pos, end - pos);
+}
+
+void HttpServer::SetTokenCookie(httplib::Response &res) {
+  res.set_header("Set-Cookie",
+                 "duckdb_ui_token=" + auth_token +
+                     "; Path=/; HttpOnly; SameSite=Strict");
+}
+
+bool HttpServer::ValidateToken(const httplib::Request &req,
+                               httplib::Response &res) {
+  if (!token_auth_enabled) {
+    return true;
+  }
+
+  // Check Authorization header: "token <TOKEN>"
+  auto auth_header = req.get_header_value("Authorization");
+  if (auth_header.size() > 6 && auth_header.compare(0, 6, "token ") == 0) {
+    if (auth_header.substr(6) == auth_token) {
+      SetTokenCookie(res);
+      return true;
+    }
+  }
+
+  // Check URL parameter: ?token=<TOKEN>
+  if (req.has_param("token")) {
+    if (req.get_param_value("token") == auth_token) {
+      SetTokenCookie(res);
+      return true;
+    }
+  }
+
+  // Check cookie: duckdb_ui_token=<TOKEN>
+  auto cookie_header = req.get_header_value("Cookie");
+  if (!cookie_header.empty()) {
+    auto cookie_token = ExtractTokenFromCookie(cookie_header);
+    if (cookie_token == auth_token) {
+      return true;
+    }
+  }
+
+  res.status = 401;
+  return false;
+}
+
 shared_ptr<DatabaseInstance> HttpServer::LockDatabaseInstance() {
   return ddb_instance.lock();
 }
@@ -221,6 +286,10 @@ void HttpServer::HandleGetInfo(const httplib::Request &req,
 
 void HttpServer::HandleGetLocalEvents(const httplib::Request &req,
                                       httplib::Response &res) {
+  if (!ValidateToken(req, res)) {
+    return;
+  }
+
   res.set_chunked_content_provider(
       "text/event-stream", [&](size_t /*offset*/, httplib::DataSink &sink) {
         if (event_dispatcher && event_dispatcher->WaitEvent(&sink)) {
@@ -234,11 +303,7 @@ void HttpServer::HandleGetLocalEvents(const httplib::Request &req,
 
 void HttpServer::HandleGetLocalToken(const httplib::Request &req,
                                      httplib::Response &res) {
-  // GET requests don't include Origin, so use Referer instead.
-  // Referer includes the path, so only compare the start.
-  auto referer = req.get_header_value("Referer");
-  if (referer.compare(0, local_url.size(), local_url) != 0) {
-    res.status = 401;
+  if (!ValidateToken(req, res)) {
     return;
   }
 
@@ -286,6 +351,10 @@ void HttpServer::InitClientFromParams(httplib::Client &client) {
 
 void HttpServer::HandleGet(const httplib::Request &req,
                            httplib::Response &res) {
+  if (!ValidateToken(req, res)) {
+    return;
+  }
+
   // Create HTTP client to remote URL
   // TODO: Can this be created once and shared?
   httplib::Client client(remote_url);
@@ -302,7 +371,10 @@ void HttpServer::HandleGet(const httplib::Request &req,
   }
 
   // forward GET to remote URL
-  auto result = client.Get(req.path, req.params, headers);
+  // Strip the token parameter before forwarding to remote
+  auto params = req.params;
+  params.erase("token");
+  auto result = client.Get(req.path, params, headers);
   if (!result) {
     res.status = 500;
     res.set_content("Could not fetch: '" + req.path + "' from '" + remote_url +
@@ -329,6 +401,10 @@ void HttpServer::HandleGet(const httplib::Request &req,
 
 void HttpServer::HandleInterrupt(const httplib::Request &req,
                                  httplib::Response &res) {
+  if (!ValidateToken(req, res)) {
+    return;
+  }
+
   auto origin = req.get_header_value("Origin");
   if (origin != local_url) {
     res.status = 401;
@@ -369,6 +445,10 @@ void HttpServer::HandleRun(const httplib::Request &req, httplib::Response &res,
 void HttpServer::DoHandleRun(const httplib::Request &req,
                              httplib::Response &res,
                              const httplib::ContentReader &content_reader) {
+  if (!ValidateToken(req, res)) {
+    return;
+  }
+
   auto origin = req.get_header_value("Origin");
   if (origin != local_url) {
     res.status = 401;
@@ -669,6 +749,10 @@ void HttpServer::DoHandleRun(const httplib::Request &req,
 void HttpServer::HandleTokenize(const httplib::Request &req,
                                 httplib::Response &res,
                                 const httplib::ContentReader &content_reader) {
+  if (!ValidateToken(req, res)) {
+    return;
+  }
+
   auto origin = req.get_header_value("Origin");
   if (origin != local_url) {
     res.status = 401;

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -101,25 +101,28 @@ const HttpServer &HttpServer::Start(ClientContext &context, bool *was_started) {
     *was_started = false;
   }
 
+  const auto host = GetLocalHost(context);
   const auto remote_url = GetRemoteUrl(context);
   const auto port = GetLocalPort(context);
   auto &http_util = HTTPUtil::Get(*context.db);
   // FIXME - https://github.com/duckdb/duckdb/pull/17655 will remove `unused`
   auto http_params = http_util.InitializeParameters(context, "unused");
   auto server = GetInstance(context);
-  server->DoStart(port, remote_url, std::move(http_params));
+  server->DoStart(host, port, remote_url, std::move(http_params));
   return *server;
 }
 
-void HttpServer::DoStart(const uint16_t _local_port,
+void HttpServer::DoStart(const std::string &_local_host,
+                         const uint16_t _local_port,
                          const std::string &_remote_url,
                          unique_ptr<HTTPParams> _http_params) {
   if (Started()) {
     throw std::runtime_error("HttpServer already started");
   }
 
+  local_host = _local_host;
   local_port = _local_port;
-  local_url = StringUtil::Format("http://localhost:%d", local_port);
+  local_url = StringUtil::Format("http://%s:%d", local_host, local_port);
   remote_url = _remote_url;
   http_params = std::move(_http_params);
   user_agent =
@@ -163,11 +166,12 @@ void HttpServer::DoStop() {
   http_params = nullptr;
   event_dispatcher = nullptr;
   remote_url = "";
+  local_host = "";
   local_port = 0;
 }
 
 std::string HttpServer::LocalUrl() const {
-  return StringUtil::Format("http://localhost:%d/", local_port);
+  return StringUtil::Format("http://%s:%d/", local_host, local_port);
 }
 
 shared_ptr<DatabaseInstance> HttpServer::LockDatabaseInstance() {
@@ -203,7 +207,7 @@ void HttpServer::Run() {
                   const httplib::ContentReader &content_reader) {
                 HandleTokenize(req, res, content_reader);
               });
-  server.listen("localhost", local_port);
+  server.listen(local_host, local_port);
 }
 
 void HttpServer::HandleGetInfo(const httplib::Request &req,

--- a/src/include/http_server.hpp
+++ b/src/include/http_server.hpp
@@ -42,8 +42,8 @@ private:
   friend class Watcher;
 
   // Lifecycle
-  void DoStart(const uint16_t local_port, const std::string &remote_url,
-               unique_ptr<HTTPParams>);
+  void DoStart(const std::string &local_host, const uint16_t local_port,
+               const std::string &remote_url, unique_ptr<HTTPParams>);
   void DoStop();
   void Run();
   void UpdateDatabaseInstance(shared_ptr<DatabaseInstance> context_db);
@@ -75,6 +75,7 @@ private:
   static void CopyAndSlice(duckdb::DataChunk &source, duckdb::DataChunk &target,
                            idx_t row_count);
 
+  std::string local_host;
   uint16_t local_port;
   std::string local_url;
   std::string remote_url;

--- a/src/include/http_server.hpp
+++ b/src/include/http_server.hpp
@@ -37,13 +37,15 @@ public:
   static bool Stop();
 
   std::string LocalUrl() const;
+  std::string GetAuthToken() const;
 
 private:
   friend class Watcher;
 
   // Lifecycle
   void DoStart(const std::string &local_host, const uint16_t local_port,
-               const std::string &remote_url, unique_ptr<HTTPParams>);
+               const std::string &remote_url, unique_ptr<HTTPParams>,
+               bool token_auth_enabled);
   void DoStop();
   void Run();
   void UpdateDatabaseInstance(shared_ptr<DatabaseInstance> context_db);
@@ -62,6 +64,11 @@ private:
   void HandleTokenize(const httplib::Request &req, httplib::Response &res,
                       const httplib::ContentReader &content_reader);
   std::string ReadContent(const httplib::ContentReader &content_reader);
+
+  // Token authentication
+  bool ValidateToken(const httplib::Request &req, httplib::Response &res);
+  void SetTokenCookie(httplib::Response &res);
+  static std::string ExtractTokenFromCookie(const std::string &cookie_header);
 
   // Http responses
   void SetResponseContent(httplib::Response &res, const MemoryStream &content);
@@ -86,6 +93,8 @@ private:
   unique_ptr<EventDispatcher> event_dispatcher;
   unique_ptr<Watcher> watcher;
   unique_ptr<HTTPParams> http_params;
+  std::string auth_token;
+  bool token_auth_enabled;
 
   static unique_ptr<HttpServer> server_instance;
 };

--- a/src/include/settings.hpp
+++ b/src/include/settings.hpp
@@ -11,6 +11,8 @@
 #define UI_REMOTE_URL_SETTING_DEFAULT "https://ui.duckdb.org"
 #define UI_POLLING_INTERVAL_SETTING_NAME "ui_polling_interval"
 #define UI_POLLING_INTERVAL_SETTING_DEFAULT 284
+#define UI_ENABLE_TOKEN_AUTH_SETTING_NAME "ui_enable_token_auth"
+#define UI_ENABLE_TOKEN_AUTH_SETTING_DEFAULT true
 
 namespace duckdb {
 
@@ -31,5 +33,6 @@ std::string GetLocalHost(const ClientContext &);
 std::string GetRemoteUrl(const ClientContext &);
 uint16_t GetLocalPort(const ClientContext &);
 uint32_t GetPollingInterval(const ClientContext &);
+bool GetEnableTokenAuth(const ClientContext &);
 
 } // namespace duckdb

--- a/src/include/settings.hpp
+++ b/src/include/settings.hpp
@@ -3,6 +3,8 @@
 #include <duckdb/common/exception.hpp>
 #include <duckdb/main/client_context.hpp>
 
+#define UI_LOCAL_HOST_SETTING_NAME "ui_local_host"
+#define UI_LOCAL_HOST_SETTING_DEFAULT "localhost"
 #define UI_LOCAL_PORT_SETTING_NAME "ui_local_port"
 #define UI_LOCAL_PORT_SETTING_DEFAULT 4213
 #define UI_REMOTE_URL_SETTING_NAME "ui_remote_url"
@@ -25,6 +27,7 @@ T GetSetting(const ClientContext &context, const char *setting_name) {
 }
 } // namespace internal
 
+std::string GetLocalHost(const ClientContext &);
 std::string GetRemoteUrl(const ClientContext &);
 uint16_t GetLocalPort(const ClientContext &);
 uint32_t GetPollingInterval(const ClientContext &);

--- a/src/include/utils/token.hpp
+++ b/src/include/utils/token.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+namespace duckdb {
+
+std::string GenerateToken();
+
+} // namespace duckdb

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -20,6 +20,10 @@ std::string GetRemoteUrl(const ClientContext &context) {
   return internal::GetSetting<std::string>(context, UI_REMOTE_URL_SETTING_NAME);
 }
 
+std::string GetLocalHost(const ClientContext &context) {
+  return internal::GetSetting<std::string>(context, UI_LOCAL_HOST_SETTING_NAME);
+}
+
 uint16_t GetLocalPort(const ClientContext &context) {
   return internal::GetSetting<uint16_t>(context, UI_LOCAL_PORT_SETTING_NAME);
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -30,6 +30,11 @@ uint16_t GetLocalPort(const ClientContext &context) {
 
 uint32_t GetPollingInterval(const ClientContext &context) {
   return internal::GetSetting<uint32_t>(context,
-                                        UI_POLLING_INTERVAL_SETTING_NAME);
+                                         UI_POLLING_INTERVAL_SETTING_NAME);
+}
+
+bool GetEnableTokenAuth(const ClientContext &context) {
+  return internal::GetSetting<bool>(context,
+                                    UI_ENABLE_TOKEN_AUTH_SETTING_NAME);
 }
 } // namespace duckdb

--- a/src/ui_extension.cpp
+++ b/src/ui_extension.cpp
@@ -29,13 +29,17 @@ std::string StartUIFunction(ClientContext &context) {
   }
 
   const auto &server = ui::HttpServer::Start(context);
-  const auto local_url = server.LocalUrl();
+  auto url = server.LocalUrl();
+  const auto token = server.GetAuthToken();
+  if (!token.empty()) {
+    url += "?token=" + token;
+  }
 
-  const auto command = StringUtil::Format("%s %s", OPEN_COMMAND, local_url);
+  const auto command = StringUtil::Format("%s %s", OPEN_COMMAND, url);
   return system(command.c_str())
              ? StringUtil::Format("Navigate browser to %s",
-                                  local_url) // open command failed
-             : StringUtil::Format("UI started at %s", local_url);
+                                  url) // open command failed
+             : StringUtil::Format("UI started at %s", url);
 }
 
 std::string StartUIServerFunction(ClientContext &context) {
@@ -46,9 +50,13 @@ std::string StartUIServerFunction(ClientContext &context) {
 
   bool was_started = false;
   const auto &server = ui::HttpServer::Start(context, &was_started);
+  auto url = server.LocalUrl();
+  const auto token = server.GetAuthToken();
+  if (!token.empty()) {
+    url += "?token=" + token;
+  }
   const char *already = was_started ? "already " : "";
-  return StringUtil::Format("UI server %sstarted at %s", already,
-                            server.LocalUrl());
+  return StringUtil::Format("UI server %sstarted at %s", already, url);
 }
 
 std::string StopUIServerFunction(ClientContext &context) {
@@ -62,7 +70,21 @@ std::string GetUIURLFunction(ClientContext &context) {
   }
 
   auto server = ui::HttpServer::GetInstance(context);
-  return server->LocalUrl();
+  auto url = server->LocalUrl();
+  const auto token = server->GetAuthToken();
+  if (!token.empty()) {
+    url += "?token=" + token;
+  }
+  return url;
+}
+
+std::string GetUITokenFunction(ClientContext &context) {
+  if (!ui::HttpServer::Started()) {
+    throw ExecutorException("UI server not started");
+  }
+
+  auto server = ui::HttpServer::GetInstance(context);
+  return server->GetAuthToken();
 }
 
 void IsUIStartedTableFunc(ClientContext &context, TableFunctionInput &input,
@@ -142,10 +164,17 @@ static void LoadInternal(DatabaseInstance &instance) {
         LogicalType::UINTEGER, Value::UINTEGER(def));
   }
 
+  config.AddExtensionOption(
+      UI_ENABLE_TOKEN_AUTH_SETTING_NAME,
+      "Enable token-based authentication for the UI server",
+      LogicalType::BOOLEAN,
+      Value::BOOLEAN(UI_ENABLE_TOKEN_AUTH_SETTING_DEFAULT));
+
   REGISTER_TF("start_ui", StartUIFunction);
   REGISTER_TF("start_ui_server", StartUIServerFunction);
   REGISTER_TF("stop_ui_server", StopUIServerFunction);
   REGISTER_TF("get_ui_url", GetUIURLFunction);
+  REGISTER_TF("get_ui_token", GetUITokenFunction);
   {
     TableFunction tf("ui_is_started", {}, IsUIStartedTableFunc,
                      internal::SingleBoolResultBind,

--- a/src/ui_extension.cpp
+++ b/src/ui_extension.cpp
@@ -108,6 +108,15 @@ static void LoadInternal(DatabaseInstance &instance) {
 
   auto &config = DBConfig::GetConfig(instance);
   {
+    auto def = GetEnvOrDefault(UI_LOCAL_HOST_SETTING_NAME,
+                               UI_LOCAL_HOST_SETTING_DEFAULT);
+    config.AddExtensionOption(
+        UI_LOCAL_HOST_SETTING_NAME,
+        "Local host on which the UI server listens",
+        LogicalType::VARCHAR, Value(def));
+  }
+
+  {
     auto default_port = GetEnvOrDefaultInt(UI_LOCAL_PORT_SETTING_NAME,
                                            UI_LOCAL_PORT_SETTING_DEFAULT);
     config.AddExtensionOption(

--- a/src/utils/token.cpp
+++ b/src/utils/token.cpp
@@ -1,0 +1,22 @@
+#include "utils/token.hpp"
+
+#include <iomanip>
+#include <random>
+#include <sstream>
+
+namespace duckdb {
+
+std::string GenerateToken() {
+	std::random_device rd;
+	std::mt19937_64 gen(rd());
+	std::uniform_int_distribution<uint64_t> dist;
+
+	std::ostringstream oss;
+	oss << std::hex << std::setfill('0');
+	for (int i = 0; i < 4; ++i) {
+		oss << std::setw(16) << dist(gen);
+	}
+	return oss.str();
+}
+
+} // namespace duckdb

--- a/test/integration/helpers/DuckDBServer.ts
+++ b/test/integration/helpers/DuckDBServer.ts
@@ -1,0 +1,129 @@
+import { execSync, spawn, type ChildProcess } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
+
+function findDuckDBBinary(): string {
+  const candidates = [
+    join(REPO_ROOT, 'build', 'release', 'duckdb'),
+    join(REPO_ROOT, 'build', 'debug', 'duckdb'),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    `DuckDB binary not found. Build the extension first with 'make' or 'make debug'. Searched:\n${candidates.join('\n')}`,
+  );
+}
+
+export interface DuckDBServerOptions {
+  port: number;
+  tokenAuth?: boolean;
+}
+
+export interface DuckDBServerInfo {
+  url: string;
+  token: string;
+  port: number;
+}
+
+export class DuckDBServer {
+  private proc: ChildProcess | null = null;
+  private info: DuckDBServerInfo | null = null;
+
+  constructor(private readonly options: DuckDBServerOptions) {}
+
+  async start(): Promise<DuckDBServerInfo> {
+    const binary = findDuckDBBinary();
+    const port = this.options.port;
+    const tokenAuth = this.options.tokenAuth ?? true;
+
+    const sql = [
+      `SET ui_local_port=${port};`,
+      `SET ui_enable_token_auth=${tokenAuth};`,
+      `SELECT * FROM start_ui_server();`,
+      `SELECT * FROM get_ui_token();`,
+    ].join('\n');
+
+    // Start DuckDB in a subprocess that stays alive (the server runs in a thread).
+    // Use -noheader -csv for clean, parseable output.
+    this.proc = spawn(binary, ['-noheader', '-csv'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    return new Promise<DuckDBServerInfo>((resolve, reject) => {
+      let stdout = '';
+      let stderr = '';
+
+      const timeout = setTimeout(() => {
+        this.stop();
+        reject(
+          new Error(
+            `Timed out waiting for DuckDB server to start.\nstdout: ${stdout}\nstderr: ${stderr}`,
+          ),
+        );
+      }, 10000);
+
+      this.proc!.stdout!.on('data', (data: Buffer) => {
+        stdout += data.toString();
+
+        // The output has two result lines:
+        // 1. "UI server started at http://localhost:<port>/?token=<token>"
+        // 2. "<token>" (from get_ui_token)
+        const lines = stdout
+          .split('\n')
+          .map((l) => l.trim())
+          .filter((l) => l.length > 0);
+
+        // Look for the token line (64-char hex string on its own line)
+        const tokenLine = lines.find((l) => /^[0-9a-f]{64}$/.test(l));
+        if (tokenLine) {
+          clearTimeout(timeout);
+          this.info = {
+            url: `http://localhost:${port}`,
+            token: tokenLine,
+            port,
+          };
+          resolve(this.info);
+        }
+      });
+
+      this.proc!.stderr!.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      this.proc!.on('close', (code) => {
+        clearTimeout(timeout);
+        if (!this.info) {
+          reject(
+            new Error(
+              `DuckDB exited with code ${code} before server started.\nstdout: ${stdout}\nstderr: ${stderr}`,
+            ),
+          );
+        }
+      });
+
+      // Send SQL commands via stdin, but don't close stdin — keep the process alive
+      this.proc!.stdin!.write(sql + '\n');
+    });
+  }
+
+  stop(): void {
+    if (this.proc) {
+      this.proc.stdin?.end();
+      this.proc.kill('SIGTERM');
+      this.proc = null;
+      this.info = null;
+    }
+  }
+
+  getInfo(): DuckDBServerInfo {
+    if (!this.info) {
+      throw new Error('Server not started');
+    }
+    return this.info;
+  }
+}

--- a/test/integration/package-lock.json
+++ b/test/integration/package-lock.json
@@ -1,0 +1,1483 @@
+{
+  "name": "duckdb-ui-integration-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "duckdb-ui-integration-tests",
+      "devDependencies": {
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "duckdb-ui-integration-tests",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
+  }
+}

--- a/test/integration/token_auth.test.ts
+++ b/test/integration/token_auth.test.ts
@@ -1,0 +1,242 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { DuckDBServer, type DuckDBServerInfo } from './helpers/DuckDBServer';
+
+// Use a high port to avoid conflicts with any running DuckDB UI
+const TEST_PORT_AUTH_ENABLED = 14213;
+const TEST_PORT_AUTH_DISABLED = 14214;
+
+describe('token auth enabled', () => {
+  const server = new DuckDBServer({
+    port: TEST_PORT_AUTH_ENABLED,
+    tokenAuth: true,
+  });
+  let info: DuckDBServerInfo;
+
+  beforeAll(async () => {
+    info = await server.start();
+  });
+
+  afterAll(() => {
+    server.stop();
+  });
+
+  // --- /info endpoint (no auth required) ---
+
+  test('/info does not require authentication', async () => {
+    const res = await fetch(`${info.url}/info`);
+    expect(res.status).toBe(200);
+  });
+
+  test('/info returns DuckDB version headers', async () => {
+    const res = await fetch(`${info.url}/info`);
+    expect(res.headers.get('X-DuckDB-Version')).toBeTruthy();
+    expect(res.headers.get('X-DuckDB-Platform')).toBeTruthy();
+    expect(res.headers.get('X-DuckDB-UI-Extension-Version')).toBeTruthy();
+  });
+
+  test('/info returns Access-Control-Allow-Origin header', async () => {
+    const res = await fetch(`${info.url}/info`);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
+
+  // --- Authentication via Authorization header ---
+
+  test('valid Authorization header grants access', async () => {
+    const res = await fetch(`${info.url}/localToken`, {
+      headers: { Authorization: `token ${info.token}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('valid Authorization header sets cookie', async () => {
+    const res = await fetch(`${info.url}/localToken`, {
+      headers: { Authorization: `token ${info.token}` },
+    });
+    const setCookie = res.headers.get('Set-Cookie');
+    expect(setCookie).toContain(`duckdb_ui_token=${info.token}`);
+    expect(setCookie).toContain('HttpOnly');
+    expect(setCookie).toContain('SameSite=Strict');
+    expect(setCookie).toContain('Path=/');
+  });
+
+  test('invalid Authorization header returns 401', async () => {
+    const res = await fetch(`${info.url}/localToken`, {
+      headers: { Authorization: 'token invalid_token' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('wrong Authorization scheme returns 401', async () => {
+    const res = await fetch(`${info.url}/localToken`, {
+      headers: { Authorization: `Bearer ${info.token}` },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('empty Authorization header returns 401', async () => {
+    const res = await fetch(`${info.url}/localToken`, {
+      headers: { Authorization: '' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  // --- Authentication via URL query parameter ---
+
+  test('valid token query parameter grants access', async () => {
+    const res = await fetch(`${info.url}/localToken?token=${info.token}`);
+    expect(res.status).toBe(200);
+  });
+
+  test('valid token query parameter sets cookie', async () => {
+    const res = await fetch(`${info.url}/localToken?token=${info.token}`);
+    const setCookie = res.headers.get('Set-Cookie');
+    expect(setCookie).toContain(`duckdb_ui_token=${info.token}`);
+  });
+
+  test('invalid token query parameter returns 401', async () => {
+    const res = await fetch(`${info.url}/localToken?token=wrong`);
+    expect(res.status).toBe(401);
+  });
+
+  // --- Authentication via Cookie ---
+
+  test('valid cookie grants access', async () => {
+    const res = await fetch(`${info.url}/localToken`, {
+      headers: { Cookie: `duckdb_ui_token=${info.token}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('valid cookie among multiple cookies grants access', async () => {
+    const res = await fetch(`${info.url}/localToken`, {
+      headers: {
+        Cookie: `other=foo; duckdb_ui_token=${info.token}; another=bar`,
+      },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('invalid cookie returns 401', async () => {
+    const res = await fetch(`${info.url}/localToken`, {
+      headers: { Cookie: 'duckdb_ui_token=wrong_token' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('missing cookie returns 401', async () => {
+    const res = await fetch(`${info.url}/localToken`, {
+      headers: { Cookie: 'other=foo' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  // --- No credentials at all ---
+
+  test('request with no credentials returns 401', async () => {
+    const res = await fetch(`${info.url}/localToken`);
+    expect(res.status).toBe(401);
+  });
+
+  // --- Token properties ---
+
+  test('token is a 64-character hex string', () => {
+    expect(info.token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  // --- Protected endpoints return 401 without auth ---
+
+  test('/localEvents returns 401 without auth', async () => {
+    const res = await fetch(`${info.url}/localEvents`);
+    expect(res.status).toBe(401);
+  });
+
+  // The catch-all GET handler proxies to remote, but requires auth first
+  test('GET / returns 401 without auth', async () => {
+    const res = await fetch(`${info.url}/`);
+    expect(res.status).toBe(401);
+  });
+
+  test('POST /ddb/run returns 401 without auth', async () => {
+    const res = await fetch(`${info.url}/ddb/run`, {
+      method: 'POST',
+      body: 'SELECT 1',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('POST /ddb/tokenize returns 401 without auth', async () => {
+    const res = await fetch(`${info.url}/ddb/tokenize`, {
+      method: 'POST',
+      body: 'SELECT 1',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('POST /ddb/interrupt returns 401 without auth', async () => {
+    const res = await fetch(`${info.url}/ddb/interrupt`, {
+      method: 'POST',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  // --- Auth grants access to protected endpoints ---
+
+  test('/localToken is accessible with valid auth', async () => {
+    const res = await fetch(`${info.url}/localToken`, {
+      headers: { Authorization: `token ${info.token}` },
+    });
+    // Returns 200 (body may be empty if MotherDuck is not connected)
+    expect(res.status).toBe(200);
+  });
+
+  test('/localEvents is accessible with valid auth', async () => {
+    const controller = new AbortController();
+    const res = await fetch(`${info.url}/localEvents`, {
+      headers: { Authorization: `token ${info.token}` },
+      signal: controller.signal,
+    });
+    // SSE endpoint returns 200 with chunked transfer
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/event-stream');
+    controller.abort();
+  });
+});
+
+describe('token auth disabled', () => {
+  const server = new DuckDBServer({
+    port: TEST_PORT_AUTH_DISABLED,
+    tokenAuth: false,
+  });
+  let info: DuckDBServerInfo;
+
+  beforeAll(async () => {
+    info = await server.start();
+  });
+
+  afterAll(() => {
+    server.stop();
+  });
+
+  test('/info is accessible without auth', async () => {
+    const res = await fetch(`${info.url}/info`);
+    expect(res.status).toBe(200);
+  });
+
+  test('/localToken is accessible without auth', async () => {
+    const res = await fetch(`${info.url}/localToken`);
+    expect(res.status).toBe(200);
+  });
+
+  test('/localEvents is accessible without auth', async () => {
+    const controller = new AbortController();
+    const res = await fetch(`${info.url}/localEvents`, {
+      signal: controller.signal,
+    });
+    expect(res.status).toBe(200);
+    controller.abort();
+  });
+
+  test('a token is still generated even when auth is disabled', () => {
+    expect(info.token).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/test/integration/tsconfig.json
+++ b/test/integration/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/test/sql/ui.test
+++ b/test/sql/ui.test
@@ -2,3 +2,25 @@
 # description: test ui extension
 # group: [sql]
 
+require ui
+
+# Verify the ui_local_host setting exists with the default value
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_local_host';
+----
+ui_local_host	localhost
+
+# Verify the ui_local_host setting can be changed
+statement ok
+SET ui_local_host = '0.0.0.0';
+
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_local_host';
+----
+ui_local_host	0.0.0.0
+
+# Verify the ui_local_port setting still works
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_local_port';
+----
+ui_local_port	4213

--- a/test/sql/ui.test
+++ b/test/sql/ui.test
@@ -24,3 +24,96 @@ query II
 SELECT name, value FROM duckdb_settings() WHERE name='ui_local_port';
 ----
 ui_local_port	4213
+
+# Verify the ui_enable_token_auth setting exists with the default value
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_enable_token_auth';
+----
+ui_enable_token_auth	true
+
+# Verify the ui_enable_token_auth setting can be changed
+statement ok
+SET ui_enable_token_auth = false;
+
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_enable_token_auth';
+----
+ui_enable_token_auth	false
+
+# Verify the ui_enable_token_auth setting can be set back to true
+statement ok
+SET ui_enable_token_auth = true;
+
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_enable_token_auth';
+----
+ui_enable_token_auth	true
+
+# Verify the ui_local_host setting can be set to 127.0.0.1
+statement ok
+SET ui_local_host = '127.0.0.1';
+
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_local_host';
+----
+ui_local_host	127.0.0.1
+
+# Verify the ui_local_host setting can be set back to localhost
+statement ok
+SET ui_local_host = 'localhost';
+
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_local_host';
+----
+ui_local_host	localhost
+
+# Verify the ui_local_port setting can be changed
+statement ok
+SET ui_local_port = 8080;
+
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_local_port';
+----
+ui_local_port	8080
+
+# Verify the ui_local_port setting can be set back to default
+statement ok
+SET ui_local_port = 4213;
+
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_local_port';
+----
+ui_local_port	4213
+
+# Verify the ui_polling_interval setting exists with the default value
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_polling_interval';
+----
+ui_polling_interval	284
+
+# Verify the ui_polling_interval setting can be changed
+statement ok
+SET ui_polling_interval = 500;
+
+query II
+SELECT name, value FROM duckdb_settings() WHERE name='ui_polling_interval';
+----
+ui_polling_interval	500
+
+# Verify get_ui_token throws before server is started
+statement error
+SELECT * FROM get_ui_token();
+----
+UI server not started
+
+# Verify get_ui_url throws before server is started
+statement error
+SELECT * FROM get_ui_url();
+----
+UI server not started
+
+# Verify ui_is_started returns false before server is started
+query I
+SELECT * FROM ui_is_started();
+----
+false


### PR DESCRIPTION
## Summary
- Add a new `ui_local_host` DuckDB extension setting (default: `localhost`) that controls the host/address the UI HTTP server binds to.
- Enables binding to `0.0.0.0` for remote/network access, e.g. `SET ui_local_host = '0.0.0.0';` or `UI_LOCAL_HOST=0.0.0.0 duckdb -ui`.
- Follows the same pattern as the existing `ui_local_port` setting: configurable via SQL, environment variable, or default.

## Changes
- **`src/include/settings.hpp`** — Define `UI_LOCAL_HOST_SETTING_NAME` / `UI_LOCAL_HOST_SETTING_DEFAULT` macros, declare `GetLocalHost()`.
- **`src/settings.cpp`** — Implement `GetLocalHost()`.
- **`src/ui_extension.cpp`** — Register `ui_local_host` as an extension option (`VARCHAR`, env-overridable).
- **`src/include/http_server.hpp`** — Add `local_host` member, update `DoStart` signature.
- **`src/http_server.cpp`** — Thread `local_host` through `Start`→`DoStart`→`Run`, use it in `server.listen()`, `LocalUrl()`, and `local_url` construction. `IsRunningOnMachine()` still probes `localhost` since that works regardless of bind address.
- **`test/sql/ui.test`** — Add SQLLogicTests verifying the setting exists, has the correct default, and can be changed.

Implemented suggestion from #232. 